### PR TITLE
check if native version is available first then try to download it

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,26 +7,29 @@ install () {
   local platform=""
   local tempdir=""
   local native_filename=""
+  local github_prefix="https://github.com/JetBrains/kotlin/releases"
 
   [ "Linux" = "$(uname)" ] && platform="linux" || platform="darwin"
   [ "linux" = "${platform}" ] && tempdir=$(mktemp -d asdf-kotlin.XXXX) || tempdir=$(mktemp -dt asdf-kotlin)
 
-  curl -L "https://github.com/JetBrains/kotlin/releases/download/v${version}/kotlin-compiler-${version}.zip" -o "${tempdir}/kotlin-compiler.zip"
+  curl -L "${github_prefix}/download/v${version}/kotlin-compiler-${version}.zip" -o "${tempdir}/kotlin-compiler.zip"
   unzip -qq "${tempdir}/kotlin-compiler.zip" -d "${install_path}"
 
-  if [[ $platform == "linux-gnu" ]]; then
-    native_filename="kotlin-native-linux-${version}.tar.gz"
+  if [[ $platform == "linux" ]]; then
+    native_filename="kotlin-native-linux-\d\.\d\.\d.tar.gz"
   elif [[ $platform == "darwin" ]]; then
-    native_filename="kotlin-native-macos-${version}.tar.gz"
+    native_filename="kotlin-native-macos-\d\.\d\.\d.tar.gz"
   fi
 
-  if [[ ! -z $native_filename ]]; then
-    local native_url="https://github.com/JetBrains/kotlin/releases/download/v${version}/${native_filename}"
+  local check_url="${github_prefix}/tag/v${version}"
+  local check_regex="/JetBrains/kotlin/releases/download/v${version}/${native_filename}"
+  local check_native=$(curl "${check_url}" | grep -P "${check_regex}" | cut -f2 -d '"')
+  if [[ ! -z $check_native ]]; then
     local native_install_path="${install_path}/kotlin-native"
 
-    curl -fL "${native_url}" -o "${tempdir}/kotlin-native.tar.gz" && \
+    curl -fL "https://github.com${check_native}" -o "${tempdir}/kotlin-native.tar.gz" && \
     mkdir -p "${native_install_path}" && \
-    (cd "${native_install_path}" && tar -xf "${tempdir}/kotlin-native.tar.gz" --strip-components=1)
+    tar -xf "${tempdir}/kotlin-native.tar.gz" --strip-components=1 --directory "${native_install_path}"
   fi
 
   rm -rf "${tempdir}"


### PR DESCRIPTION
Seems to work

```
$ kotlinc-native -version
info: kotlinc-native 1.3.20 (JRE 1.8.0_171-b11)
Kotlin/Native: 1.1.1
```