### PR TITLE
Trying to add bash's strict-mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,11 @@ script:
     asdf install kotlin 1.3.21
     echo "Setting kotlin 1.0.3 as the default value in ~/.tool-versions"
     echo 'kotlin 1.0.3' >> ~/.tool-versions
+    echo "Confirming version 1.0.3"
+    kotlin -version | grep '1.0.3'
     echo "Confirming version 1.3.21"
+    echo "java openjdk-11.0.1" > ~/.tool-versions
+    echo 'kotlin 1.3.21' >> ~/.tool-versions
     kotlin -version | grep '1.3.21'
     kotlinc-native -version | grep '1.3.21'
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,26 @@
 language: java
-script: asdf plugin-test kotlin https://github.com/missingcharacter/asdf-kotlin.git
+script:
+  - |
+    echo "Will running plugin-test"
+    asdf plugin-test kotlin https://github.com/missingcharacter/asdf-kotlin.git
+    echo "Adding kotlin and java via 'asdf plugin-add'"
+    asdf plugin-add kotlin
+    asdf plugin-add java
+    echo "Will try to install java's openjdk-11.0.1"
+    asdf install java openjdk-11.0.1
+    echo "Trying to list all versions of kotlin"
+    asdf list-all kotlin
+    echo "Will add 'java openjdk-11.0.1' to "
+    echo "java openjdk-11.0.1" > ~/.tool-versions
+    echo "Will try to install kotlin 1.0.3 (version without kotlin native)"
+    asdf install kotlin 1.0.3
+    echo "Will try to install kotlin 1.3.21 (version with kotlin native)"
+    asdf install kotlin 1.3.21
+    echo "Setting kotlin 1.0.3 as the default value in ~/.tool-versions"
+    echo 'kotlin 1.0.3' >> ~/.tool-versions
+    echo "Confirming version 1.3.21"
+    kotlin -version | grep '1.3.21'
+    kotlinc-native -version | grep '1.3.21'
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git asdf
   - . asdf/asdf.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 script:
   - |
-    echo "Will running plugin-test"
+    echo "Will run plugin-test"
     asdf plugin-test kotlin https://github.com/missingcharacter/asdf-kotlin.git
     echo "Adding kotlin and java via 'asdf plugin-add'"
     asdf plugin-add kotlin
@@ -10,7 +10,7 @@ script:
     asdf install java openjdk-11.0.1
     echo "Trying to list all versions of kotlin"
     asdf list-all kotlin
-    echo "Will add 'java openjdk-11.0.1' to "
+    echo "Will add 'java openjdk-11.0.1' to ~/.tool-versions"
     echo "java openjdk-11.0.1" > ~/.tool-versions
     echo "Will try to install kotlin 1.0.3 (version without kotlin native)"
     asdf install kotlin 1.0.3
@@ -19,12 +19,13 @@ script:
     echo "Setting kotlin 1.0.3 as the default value in ~/.tool-versions"
     echo 'kotlin 1.0.3' >> ~/.tool-versions
     echo "Confirming version 1.0.3"
-    kotlin -version | grep '1.0.3'
-    echo "Confirming version 1.3.21"
+    kotlin -version 2>&1 | grep '1.0.3'
+    echo "Setting kotlin 1.3.21 as the default value in ~/.tool-versions"
     echo "java openjdk-11.0.1" > ~/.tool-versions
     echo 'kotlin 1.3.21' >> ~/.tool-versions
-    kotlin -version | grep '1.3.21'
-    kotlinc-native -version | grep '1.3.21'
+    echo "Confirming version 1.3.21"
+    kotlin -version 2>&1 | grep '1.3.21'
+    kotlinc-native -version 2>&1 | grep '1.3.21'
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git asdf
   - . asdf/asdf.sh

--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ Feel free to create an issue or pull request if you find a bug.
 
 ## License
 MIT License
+
+## Tests
+
+**Note**: See [.travis.yml](./.travis.yml)
+
+- It tests installing a version of kotlin without kotlin native (Version 1.0.3) on mac and linux
+- It tests installing a version of kotlin with kotlin native (Version 1.3.21) on mac and linux

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
-if [ "${KOTLIN_HOME}" = "" ] ; then
+if [[ -z ${KOTLIN_HOME:-""} ]] ; then
     export KOTLIN_HOME=${ASDF_INSTALL_PATH}/kotlinc
 fi

--- a/bin/install
+++ b/bin/install
@@ -1,31 +1,49 @@
 #!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# Ensure dependencies are present
+if [[ ! -x $(which curl) ]] || [[ ! -x $(which tar) ]] || [[ ! -x $(which unzip) ]]; then
+    echo "[-] Dependencies unmet.  Please verify that the following are installed and in the PATH:  curl, tar or unzip" >&2
+    exit 1
+fi
 
 # the releases page version does not line up with the kotlin version
 # so fetch the native-x.y.z version from the releases page
 get_native_download_url () {
-  version=$1
-  check_url=$2
-  platform=$3
+  local version=${1}
+  local check_url=${2}
+  local platform=${3}
+  local tempdir=""
 
-  local grep_command=""
+  local grep_option=""
   local native_filename=""
-  if [[ $platform == "linux" ]]; then
+  if [[ "${platform}" == "linux" ]]; then
     native_filename="kotlin-native-linux-\d\.\d\.\d.tar.gz"
-    grep_command="grep -P"
-  elif [[ $platform == "darwin" ]]; then
+    grep_option="-P"
+    tempdir=$(mktemp -d asdf-kotlin-native.XXXX)
+  elif [[ "${platform}" == "darwin" ]]; then
     native_filename="kotlin-native-macos-\d\.\d\.\d.tar.gz"
-    grep_command="grep -E"
+    grep_option="-E"
+    tempdir=$(mktemp -dt asdf-kotlin-native)
   fi
 
   local check_regex="/JetBrains/kotlin/releases/download/v${version}/${native_filename}"
-  local check_native=$(curl "${check_url}" | $grep_command "${check_regex}" | cut -f2 -d '"')
-  echo $check_native
+  local temp_html="${tempdir}/github-kotlin-release-v${version}.html"
+  curl --disable "${check_url}" -o "${temp_html}"
+  if grep ${grep_option} "${check_regex}" "${temp_html}" > /dev/null; then
+    local check_native=$(grep ${grep_option} "${check_regex}" "${temp_html}" | cut -f2 -d '"')
+  else
+    local check_native=""
+  fi
+  rm -rf "${tempdir}"
+  echo "${check_native}"
 }
 
 install () {
-  local install_type=$1
-  local version=$2
-  local install_path=$3
+  local install_type=${1}
+  local version=${2}
+  local install_path=${3}
   local platform=""
   local tempdir=""
 
@@ -34,16 +52,23 @@ install () {
   [ "Linux" = "$(uname)" ] && platform="linux" || platform="darwin"
   [ "linux" = "${platform}" ] && tempdir=$(mktemp -d asdf-kotlin.XXXX) || tempdir=$(mktemp -dt asdf-kotlin)
 
-  curl -L "${github_prefix}/download/v${version}/kotlin-compiler-${version}.zip" -o "${tempdir}/kotlin-compiler.zip"
+  echo "Trying to donload ${github_prefix}/download/v${version}/kotlin-compiler-${version}.zip to ${tempdir}/kotlin-compiler.zip"
+  curl -L  "${github_prefix}/download/v${version}/kotlin-compiler-${version}.zip" -o "${tempdir}/kotlin-compiler.zip"
+  echo "Trying to unzip ${tempdir}/kotlin-compiler.zip to ${install_path}"
   unzip -qq "${tempdir}/kotlin-compiler.zip" -d "${install_path}"
 
   local check_url="${github_prefix}/tag/v${version}"
-  local native_download_url=$(get_native_download_url $version $check_url $platform)
+  echo "Variable check_url was set to ${check_url}"
+  local native_download_url=$(get_native_download_url "${version}" "${check_url}" "${platform}")
+  echo "Variable native_download_url was set to ${native_download_url}"
   if [[ ! -z $native_download_url ]]; then
     local native_install_path="${install_path}/kotlin-native"
 
-    curl -fL "https://github.com${native_download_url}" -o "${tempdir}/kotlin-native.tar.gz" && \
-    mkdir -p "${native_install_path}" && \
+    echo "Trying to download https://github.com${native_download_url} to ${tempdir}/kotlin-native.tar.gz"
+    curl -fL "https://github.com${native_download_url}" -o "${tempdir}/kotlin-native.tar.gz"
+    echo "Creating dir ${native_install_path}"
+    mkdir -p "${native_install_path}"
+    echo "Decompressing ${tempdir}/kotlin-native.tar.gz to ${native_install_path}"
     tar -xf "${tempdir}/kotlin-native.tar.gz" --strip-components=1 --directory "${native_install_path}"
   fi
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
-
-set \
-  -o nounset \
-  -o pipefail \
-  -o errexit
+set -euo pipefail
+IFS=$'\n\t'
 
 # Repository URL
 readonly repo="https://github.com/JetBrains/kotlin"

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
 echo -n "kotlinc/bin" "kotlin-native/bin"


### PR DESCRIPTION
Changes:

- These scripts now use [Unofficial Bash Strict Mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/)
- Tests check strict mode work with:
  - [list-all](https://github.com/missingcharacter/asdf-kotlin/blob/strict-mode/.travis.yml#L11-L12)
  - [install](https://github.com/missingcharacter/asdf-kotlin/blob/strict-mode/.travis.yml#L15-L18)
  - [exec-env](https://github.com/missingcharacter/asdf-kotlin/blob/strict-mode/.travis.yml#L19-L28)
- Why were these changes implemented?
  - I'm trying to make it easier to find problems and make sure this plugin works with mac and linux