### PR TITLE
Allow unbounded variable in exec

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 IFS=$'\n\t'
 
 if [[ -z ${KOTLIN_HOME:-""} ]] ; then


### PR DESCRIPTION
Allows unbounded variable when calling a shimmed command with no arguments.

Fixes:

```
$ kotlinc
/Users/thomas/.asdf/lib/commands/shim-exec.sh: line 21: shim_args[@]: unbound variable
```