### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 ---
 name: Build
+permissions:
+  contents: read
 on:
   schedule:
     - cron: "0 23 * * 1"


### PR DESCRIPTION
Potential fix for [https://github.com/asdf-community/asdf-kotlin/security/code-scanning/8](https://github.com/asdf-community/asdf-kotlin/security/code-scanning/8)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow appears to only check out code and run tests, it likely only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just below the `name` key), so it applies to all jobs. This change should be made in `.github/workflows/build.yml` after the `name: Build` line and before the `on:` block. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
